### PR TITLE
feat: add coin detail route

### DIFF
--- a/src/components/ApplicationShell/ApplicationShell.tsx
+++ b/src/components/ApplicationShell/ApplicationShell.tsx
@@ -3,6 +3,7 @@ import { Footer } from "@/components/ApplicationShell/Footer";
 import { CryptosPage } from "@/pages/CryptosPage";
 import { PortfolioPage } from "@/pages/PortfolioPage";
 import { WidgetsPage } from "@/pages/WidgetsPage";
+import { CoinDetailPage } from "@/pages/CoinDetailPage";
 import { Route, Routes } from "react-router-dom";
 
 function ApplicationShell() {
@@ -15,6 +16,7 @@ function ApplicationShell() {
         <Route path="/" element={<CryptosPage />} />
         <Route path="/portfolio" element={<PortfolioPage />} />
         <Route path="/widgets" element={<WidgetsPage />} />
+        <Route path="/:coinId" element={<CoinDetailPage />} />
       </Routes>
 
       <Footer />

--- a/src/components/ui/CryptoSearchbar.tsx
+++ b/src/components/ui/CryptoSearchbar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from "react";
 import { nanoid } from "nanoid";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMagnifyingGlass } from "@/assets/icons";
+import { Link } from "react-router-dom";
 
 export const CryptoSearchbar = (props: any) => {
   let cryptoList = props.data;
@@ -73,13 +74,9 @@ export const CryptoSearchbar = (props: any) => {
 
           {/* Results */}
           {filteredData.map((crypto: any) => (
-            <a
-              href={`https://www.coingecko.com/en/coins/${crypto.id}`}
-              key={nanoid()}
-              className="block"
-            >
+            <Link to={`/${crypto.id}`} key={nanoid()} className="block">
               <li
-                className="flex justify-between items-center rounded py-1.5 px-2 
+                className="flex justify-between items-center rounded py-1.5 px-2
                   text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
               >
                 <div className="flex items-center gap-2">
@@ -90,7 +87,7 @@ export const CryptoSearchbar = (props: any) => {
                 </div>
                 <p>#{crypto.market_cap_rank}</p>
               </li>
-            </a>
+            </Link>
           ))}
         </ul>
       )}

--- a/src/components/widgets/Scroller.tsx
+++ b/src/components/widgets/Scroller.tsx
@@ -1,4 +1,5 @@
 import { Percent } from "@/components/ui/Percent";
+import { Link } from "react-router-dom";
 
 type CryptoData = {
   id: string;
@@ -9,7 +10,6 @@ type CryptoData = {
   price_change_percentage_24h_in_currency: number;
 };
 
-const coingeckoUrl = "https://www.coingecko.com/en/coins/";
 const currencies = [
   "bitcoin",
   "ethereum",
@@ -31,11 +31,9 @@ export const Scroller = ({ cryptos }: { cryptos: CryptoData[] }) => {
     <div className="w-full bg-white dark:bg-gray-800 py-1 border-t border-b border-gray-100 dark:border-gray-700 overflow-hidden">
       <div className="animate-marquee hover:pause-animation flex whitespace-nowrap">
         {[...cryptoData, ...cryptoData].map((crypto, index) => (
-          <a
+          <Link
             key={`${crypto.id}-${index}`}
-            href={`${coingeckoUrl}${crypto.id}`}
-            target="_blank"
-            rel="noopener"
+            to={`/${crypto.id}`}
             className="inline-flex items-center min-w-64 max-w-80 px-6 border-x border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors shrink-0"
           >
             <img
@@ -63,7 +61,7 @@ export const Scroller = ({ cryptos }: { cryptos: CryptoData[] }) => {
               </p>
               <Percent value={crypto.price_change_percentage_24h_in_currency} />
             </div>
-          </a>
+          </Link>
         ))}
       </div>
 

--- a/src/components/widgets/Trending.tsx
+++ b/src/components/widgets/Trending.tsx
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import { Link } from "react-router-dom";
 
 type TrendingItem = {
   item: {
@@ -19,11 +20,9 @@ export const Trending = ({ cryptos }: { cryptos: TrendingItem[] }) => {
 
       <div className="space-y-1 overflow-y-auto max-h-[100%]">
         {cryptos.map((crypto) => (
-          <a
+          <Link
             key={nanoid()}
-            href={`https://www.coingecko.com/en/coins/${crypto.item.id}`}
-            target="_blank"
-            rel="noopener"
+            to={`/${crypto.item.id}`}
             className="flex items-center space-x-3 p-2 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md transition-colors"
           >
             <span className="text-gray-500 dark:text-gray-400 min-w-[40px] text-left">
@@ -44,7 +43,7 @@ export const Trending = ({ cryptos }: { cryptos: TrendingItem[] }) => {
                 {crypto.item.symbol}
               </span>
             </div>
-          </a>
+          </Link>
         ))}
       </div>
     </div>

--- a/src/pages/CoinDetailPage.tsx
+++ b/src/pages/CoinDetailPage.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+
+export const CoinDetailPage = () => {
+  const { coinId } = useParams();
+  const [coin, setCoin] = useState<any>(null);
+
+  useEffect(() => {
+    if (coinId) {
+      const headers = {
+        accept: "application/json",
+        "x-cg-demo-api-key": import.meta.env.VITE_COINGECKO_DEMO_API_KEY,
+      } as any;
+
+      axios
+        .get(`https://api.coingecko.com/api/v3/coins/${coinId}`, { headers })
+        .then((res) => {
+          setCoin(res.data);
+        })
+        .catch((err) => {
+          console.error("Error fetching coin data: ", err);
+        });
+    }
+  }, [coinId]);
+
+  if (!coin) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="p-4 max-w-4xl mx-auto">
+      <div className="flex items-center gap-4">
+        <img src={coin.image?.large} alt={coin.name} className="h-16 w-16" />
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+          {coin.name}
+        </h1>
+      </div>
+      <p className="mt-4 text-gray-700 dark:text-gray-300">
+        Current Price: $
+        {coin.market_data?.current_price?.usd?.toLocaleString()}
+      </p>
+    </div>
+  );
+};
+
+export default CoinDetailPage;

--- a/src/pages/CryptosPage.tsx
+++ b/src/pages/CryptosPage.tsx
@@ -6,9 +6,9 @@ import { Percent } from "@/components/ui/Percent";
 import useLocalStorage from "@/hooks/useLocalStorage";
 import { faStarFilled, faStarEmpty, faAngleLeft, faAngleRight } from "@/assets/icons";
 import { useCryptoData } from "@/hooks/useCryptoData";
+import { Link } from "react-router-dom";
 
 export const CryptosPage = () => {
-  const coingeckoUrl = "https://www.coingecko.com/en/coins/";
   const [pageNum, setPageNum] = useState(1);
   const [favorites, setFavorites] = useLocalStorage("favorites", []);
   const { cryptos, fetchCryptos } = useCryptoData();
@@ -112,12 +112,7 @@ export const CryptosPage = () => {
                 </td>
 
                 <td className="px-1">
-                  <a
-                    href={`${coingeckoUrl}${crypto.id}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex gap-3 items-center"
-                  >
+                  <Link to={`/${crypto.id}`} className="flex gap-3 items-center">
                     <img
                       className="rounded-full h-[30px] w-[30px]"
                       src={crypto.image}
@@ -129,7 +124,7 @@ export const CryptosPage = () => {
                     <p className="text-sm font-semibold uppercase">
                       {crypto.symbol}
                     </p>
-                  </a>
+                  </Link>
                 </td>
 
                 <td className="text-right px-1">

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -20,6 +20,7 @@ import { ModalAddTransaction } from "@/components/Portfolio/ModalAddTransaction"
 import { ModalEditTransaction } from "@/components/Portfolio/ModalEditTransaction";
 import { ModalCreatePortfolio } from "@/components/Portfolio/ModalCreatePortfolio";
 import { useCryptoData } from "@/hooks/useCryptoData";
+import { Link } from "react-router-dom";
 
 export const PortfolioPage = () => {
   const { cryptos } = useCryptoData() as any;
@@ -64,8 +65,6 @@ export const PortfolioPage = () => {
       profitLoss: 100,
     },
   ]);
-
-  const coingeckoUrl = "https://www.coingecko.com/en/coins/";
 
   function sortPortfolioHoldings(holdings: any) {
     let sortedHoldings = [...holdings];
@@ -457,10 +456,8 @@ export const PortfolioPage = () => {
                       </td>
 
                       <td>
-                        <a
-                          href={`${coingeckoUrl}${crypto.id}`}
-                          target="_blank"
-                          rel="noopener"
+                        <Link
+                          to={`/${crypto.id}`}
                           className="flex items-center gap-3"
                         >
                           <img
@@ -474,7 +471,7 @@ export const PortfolioPage = () => {
                           <p className="text-sm font-semibold uppercase">
                             {crypto.symbol}
                           </p>
-                        </a>
+                        </Link>
                       </td>
 
                       <td className="text-right">


### PR DESCRIPTION
## Summary
- add dynamic route `/:coinId` to display coin details
- convert external CoinGecko links to internal navigation across pages and widgets
- implement `CoinDetailPage` that fetches and shows coin data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6890acbcf8dc832885f3c6ede429ca99