### PR TITLE
Use stable identifiers for React list keys

### DIFF
--- a/src/components/Portfolio/ModalAddTransaction.tsx
+++ b/src/components/Portfolio/ModalAddTransaction.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from "react";
-import { nanoid } from "nanoid";
 
 export const ModalAddTransaction = ({
   cryptos,
@@ -63,7 +62,7 @@ export const ModalAddTransaction = ({
       <div className="flex bg-gray-100 dark:bg-gray-800 p-1 rounded-lg">
         {txTypes.map((tab) => (
           <button
-            key={nanoid()}
+            key={tab}
             className={`
               flex-1 py-2.5 px-4 rounded-md text-sm font-semibold transition-colors
               ${
@@ -95,7 +94,7 @@ export const ModalAddTransaction = ({
           }}
         >
           {cryptos.map((crypto: any) => (
-            <option key={nanoid()} value={crypto.id}>
+            <option key={crypto.id} value={crypto.id}>
               {crypto.name}
             </option>
           ))}

--- a/src/components/ui/CryptoSearchbar.tsx
+++ b/src/components/ui/CryptoSearchbar.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useRef } from "react";
-import { nanoid } from "nanoid";
+import React, { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMagnifyingGlass } from "@/assets/icons";
 
@@ -75,7 +74,7 @@ export const CryptoSearchbar = (props: any) => {
           {filteredData.map((crypto: any) => (
             <a
               href={`https://www.coingecko.com/en/coins/${crypto.id}`}
-              key={nanoid()}
+              key={crypto.id}
               className="block"
             >
               <li

--- a/src/components/widgets/Trending.tsx
+++ b/src/components/widgets/Trending.tsx
@@ -1,4 +1,3 @@
-import { nanoid } from "nanoid";
 
 type TrendingItem = {
   item: {
@@ -20,7 +19,7 @@ export const Trending = ({ cryptos }: { cryptos: TrendingItem[] }) => {
       <div className="space-y-1 overflow-y-auto max-h-[100%]">
         {cryptos.map((crypto) => (
           <a
-            key={nanoid()}
+            key={crypto.item.id}
             href={`https://www.coingecko.com/en/coins/${crypto.item.id}`}
             target="_blank"
             rel="noopener"

--- a/src/pages/CryptosPage.tsx
+++ b/src/pages/CryptosPage.tsx
@@ -1,5 +1,4 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { nanoid } from "nanoid";
 import { useEffect, useState } from "react";
 import { Sparklines, SparklinesLine } from "react-sparklines";
 import { Percent } from "@/components/ui/Percent";
@@ -49,7 +48,7 @@ export const CryptosPage = () => {
 
     return pages.map((page) => (
       <button
-        key={nanoid()}
+        key={page}
         className={`
           px-3 py-2 font-medium border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-100
           ${page === pageNum ? "bg-gray-100 dark:bg-gray-700" : "bg-inherit text-gray-700 dark:text-gray-400"}

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { Percent } from "@/components/ui/Percent";
 import { Private } from "@/components/ui/Private";
-import { nanoid } from "nanoid";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faWallet,
@@ -342,7 +341,7 @@ export const PortfolioPage = () => {
                 const percent = getPortfolioProportion(holding) * 100;
                 return (
                   <div
-                    key={nanoid()}
+                    key={holding.id}
                     className="h-3 relative first:rounded-l-lg last:rounded-r-lg group"
                     style={{
                       width: `${percent}%`,
@@ -449,7 +448,7 @@ export const PortfolioPage = () => {
 
                   return (
                     <tr
-                      key={nanoid()}
+                      key={held.id}
                       className="h-[4.2em] border-b border-gray-100 dark:border-gray-700 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800"
                     >
                       <td className="text-center font-semibold">

--- a/src/pages/WidgetsPage.tsx
+++ b/src/pages/WidgetsPage.tsx
@@ -1,4 +1,3 @@
-import { nanoid } from "nanoid";
 import { CryptoCard } from "@/components/widgets/CryptoCard";
 import { Dominance } from "@/components/widgets/Dominance";
 import { EthGasTracker } from "@/components/widgets/EthGasTracker";
@@ -17,7 +16,7 @@ export const WidgetsPage = () => {
       <div className="flex flex-col gap-4 p-4">
         <div className="flex justify-center flex-wrap gap-4">
           {cryptos.slice(0, 5).map((crypto: any) => (
-            <CryptoCard crypto={crypto} key={nanoid()} />
+            <CryptoCard crypto={crypto} key={crypto.id} />
           ))}
         </div>
 


### PR DESCRIPTION
## Summary
- Remove `nanoid` usage and rely on stable IDs from data for list keys
- Prevent unnecessary React remounts across search, widgets, and portfolio components

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6890ac9b424c832886fc17f76f3eec6a