### PR TITLE
feat: enhance coin detail page UI

### DIFF
--- a/src/hooks/useCryptoData.tsx
+++ b/src/hooks/useCryptoData.tsx
@@ -54,7 +54,7 @@ export function useCryptoData() {
       'x-cg-demo-api-key': import.meta.env.VITE_COINGECKO_DEMO_API_KEY,
     } as any;
 
-    const cryptosUrl = `${baseUrl}coins/${coinId}`;
+    const cryptosUrl = `${baseUrl}coins/${coinId}?sparkline=true`;
     axios
       .get(cryptosUrl, { headers })
       .then((response: any) => {

--- a/src/pages/CoinDetailPage.tsx
+++ b/src/pages/CoinDetailPage.tsx
@@ -1,7 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import axios from 'axios';
 import { useCryptoData } from '@/hooks/useCryptoData';
+import type { TCoinDetail } from '@/type';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
 
 export const CoinDetailPage = () => {
   const { coinId } = useParams();
@@ -17,22 +25,104 @@ export const CoinDetailPage = () => {
     return <div className="p-4">Loading...</div>;
   }
 
+  const detail = cryptosDetail as TCoinDetail;
+  const sparklineData =
+    detail.market_data?.sparkline_7d?.price?.map((p, idx) => ({
+      time: idx,
+      price: p,
+    })) || [];
+
   return (
-    <div className="p-4 max-w-4xl mx-auto">
-      <div className="flex items-center gap-4">
-        <img
-          src={cryptosDetail.image?.large}
-          alt={cryptosDetail.name}
-          className="h-16 w-16"
-        />
-        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-          {cryptosDetail.name}
-        </h1>
+    <div className="p-4 max-w-7xl mx-auto flex gap-4">
+      <div className="w-1/5 space-y-4">
+        <div className="flex items-center gap-4">
+          <img
+            src={detail.image?.large}
+            alt={detail.name}
+            className="h-16 w-16"
+          />
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+              {detail.name}
+            </h1>
+            <p className="uppercase text-gray-500 dark:text-gray-400">
+              {detail.symbol}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4">
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+            <p className="text-sm text-gray-500 dark:text-gray-400">Current Price</p>
+            <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              ${detail.market_data?.current_price?.usd?.toLocaleString()}
+            </p>
+          </div>
+
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+            <p className="text-sm text-gray-500 dark:text-gray-400">Market Cap</p>
+            <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              ${detail.market_data?.market_cap?.usd?.toLocaleString()}
+            </p>
+          </div>
+
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+            <p className="text-sm text-gray-500 dark:text-gray-400">24h Volume</p>
+            <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              ${detail.market_data?.total_volume?.usd?.toLocaleString()}
+            </p>
+          </div>
+
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+            <p className="text-sm text-gray-500 dark:text-gray-400">24h High</p>
+            <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              ${detail.market_data?.high_24h?.usd?.toLocaleString()}
+            </p>
+          </div>
+
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+            <p className="text-sm text-gray-500 dark:text-gray-400">24h Low</p>
+            <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              ${detail.market_data?.low_24h?.usd?.toLocaleString()}
+            </p>
+          </div>
+
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+            <p className="text-sm text-gray-500 dark:text-gray-400">Market Cap Rank</p>
+            <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              #{detail.market_cap_rank}
+            </p>
+          </div>
+        </div>
       </div>
-      <p className="mt-4 text-gray-700 dark:text-gray-300">
-        Current Price: $
-        {cryptosDetail.market_data?.current_price?.usd?.toLocaleString()}
-      </p>
+
+      <div className="w-3/5 bg-white dark:bg-gray-800 p-4 rounded shadow">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          Price (7d)
+        </h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={sparklineData}>
+            <Line type="monotone" dataKey="price" stroke="#8884d8" dot={false} />
+            <XAxis dataKey="time" hide />
+            <YAxis domain={["auto", "auto"]} />
+            <Tooltip />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="w-1/5">
+        {detail.description?.en && (
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow h-full overflow-y-auto">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+              About {detail.name}
+            </h2>
+            <p
+              className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed"
+              dangerouslySetInnerHTML={{ __html: detail.description.en }}
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/type.ts
+++ b/src/type.ts
@@ -110,6 +110,7 @@ export type TCoinDetail = {
     atl: Record<string, number>;
     atl_change_percentage: Record<string, number>;
     atl_date: Record<string, string>;
+    sparkline_7d?: { price: number[] };
     last_updated: string;
   };
   last_updated: string;


### PR DESCRIPTION
## Summary
- fetch sparkline data for selected coin and extend type definitions
- redesign coin detail page into three columns with a central price chart

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6890b976e8e483289b34761879177e05