### PR TITLE
feat: add lightweight chart to coin detail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.3.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "axios": "^1.4.0",
+        "lightweight-charts": "^5.0.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.4",
@@ -1516,6 +1517,12 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-equals": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
@@ -1823,6 +1830,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.0.8.tgz",
+      "integrity": "sha512-dNBK5TlNcG78RUnxYRAZP4XpY5bkp3EE0PPjFFPkdIZ8RvnvL2JLgTb1BLh40trHhgJl51b1bCz8678GpnKvIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
       }
     },
     "node_modules/lilconfig": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.3.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "axios": "^1.4.0",
+    "lightweight-charts": "^5.0.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.4",


### PR DESCRIPTION
## Summary
- integrate TradingView's lightweight-charts for coin detail charts
- derive sparkline data and render responsive line chart

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6890c14459888328b87d82a0c943bc67