### PR TITLE
fix: align chart hooks with data availability

### DIFF
--- a/src/pages/CoinDetailPage.tsx
+++ b/src/pages/CoinDetailPage.tsx
@@ -13,30 +13,30 @@ export const CoinDetailPage = () => {
   const { coinId } = useParams();
   const { cryptosDetail, fetchCryptosById } = useCryptoData();
 
-  useEffect(() => {
-    if (coinId) {
-      fetchCryptosById(coinId);
-    }
-  }, [coinId]);
-
-  if (!cryptosDetail) {
-    return <div className="p-4">Loading...</div>;
-  }
-
-  const detail = cryptosDetail as TCoinDetail;
+  const chartContainerRef = useRef<HTMLDivElement>(null);
   const now = Math.floor(Date.now() / 1000);
   const sparklineData =
-    detail.market_data?.sparkline_7d?.price?.map(
+    cryptosDetail?.market_data?.sparkline_7d?.price?.map(
       (p, idx, arr) =>
         ({
           time: (now - (arr.length - idx) * 3600) as UTCTimestamp,
           value: p,
         }) as const,
     ) || [];
-  const chartContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!chartContainerRef.current) return;
+    if (coinId) {
+      fetchCryptosById(coinId);
+    }
+  }, [coinId]);
+
+  useEffect(() => {
+    if (
+      !cryptosDetail ||
+      sparklineData.length === 0 ||
+      !chartContainerRef.current
+    )
+      return;
     const chart = createChart(chartContainerRef.current, {
       width: chartContainerRef.current.clientWidth,
       height: 300,
@@ -68,7 +68,13 @@ export const CoinDetailPage = () => {
       window.removeEventListener('resize', handleResize);
       chart.remove();
     };
-  }, [sparklineData]);
+  }, [cryptosDetail, sparklineData]);
+
+  if (!cryptosDetail) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  const detail = cryptosDetail as TCoinDetail;
 
   return (
     <div className="p-4 max-w-7xl mx-auto flex gap-4">


### PR DESCRIPTION
## Summary
- keep chart hook order stable by declaring chartRef and effect before data check
- skip chart render when crypto detail or sparkline data are missing

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_689363add3188328bd43bf40ffc02ccb